### PR TITLE
Fixed wrong season name

### DIFF
--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -249,7 +249,7 @@ class TVShow(object):
             self._seasons = []
             for season in data:
                 extract_ids(season)
-                self._seasons.append(TVSeason(self.title, season.number,
+                self._seasons.append(TVSeason(self.title, season['number'],
                                               **season))
         yield self._seasons
 


### PR DESCRIPTION
instead of season.name which returns no attribute

use `season['number]` instead to return the value of key-value 'number'